### PR TITLE
Lower-case "number" in type conversion error message

### DIFF
--- a/lib/argp.js
+++ b/lib/argp.js
@@ -184,7 +184,7 @@ Argp.prototype._convertType = function (o){
   if (o.opt.type === Number){
     var v = Number (o.value);
     if (isNaN (v)){
-      return this._errorConvert (o.long || o.short, "Number");
+      return this._errorConvert (o.long || o.short, "number");
     }
     //Note: Number(null) returns 0, the default value
     o.value = v;


### PR DESCRIPTION
Changed the format of type conversion errors involving the Number type
so that "number" appears in lower-case:

  testprog: Option 'testopt' is not a number
  Try 'testprog --help' for more information